### PR TITLE
Add Brickken to whitelist

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -102,6 +102,7 @@
     "celoscan.io",
     "bobascan.com",
     "basescan.org",
+    "brickken.com",
 
     "rabby.io",
     "rainbow.me"


### PR DESCRIPTION
Our userbase is constantly being targeted by scammers, by the use of Defillama plugin we want to create a campaign to inform our users to use the plugin and always check for the green light before operating on any website resembling us.