### PR TITLE
[Re-open] Add Brickken to whitelist

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -102,6 +102,7 @@
     "celoscan.io",
     "bobascan.com",
     "basescan.org",
+    "brickken.com",
 
     "rabby.io",
     "rainbow.me"


### PR DESCRIPTION
Hey @0xStrobe

Based on your response [here](https://github.com/DefiLlama/url-directory/pull/11#issuecomment-1910994007) I might have not clarified enough the issue. The thing is that it should already work as you mentioned but it is not indeed. That's why I opened a PR to manually add the domain into the whitelist. What would be a better suggestion ?

![image](https://github.com/DefiLlama/url-directory/assets/20795374/bec47f61-0cb8-48cb-bd56-b1deb938a636)
