### PR TITLE
Add Emblem Vault domains (wallet infrastructure)

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -120,7 +120,11 @@
     "hyperlane.xyz",
 
     "rabby.io",
-    "rainbow.me"
+    "rainbow.me",
+
+    "emblemvault.dev",
+    "emblem.finance",
+    "agenthustle.ai"
   ],
   "blacklist": [
     "defillaman.com",


### PR DESCRIPTION
## Adding Emblem Vault domains

Emblem Vault is a cross-chain wallet infrastructure provider (not a DeFi protocol with TVL). Our products enable wallet operations across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin).

### Domains added:

| Domain | Purpose |
|--------|--------|
| `emblemvault.dev` | Developer documentation & company site |
| `emblem.finance` | Portal to interact with our ERC-721 and ERC-1155 vaults  |
| `agenthustle.ai` | AI agent wallet product (EmblemAI) |

### Why whitelist:
- **Wallet app** — users interact with these domains to manage cross-chain assets
- **Active since 2020** — established project with real users
- **GitHub**: [EmblemCompany](https://github.com/EmblemCompany)

These are not DeFi protocols — they are wallet/infrastructure products, matching the scope of this directory (similar to rabby.io, rainbow.me, opensea.io already in the list).