### PR TITLE
Add clobr.io

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -23,6 +23,7 @@
     "rabbithole.gg",
     "polygon.technology",
     "dexscreener.com",
+    "clobr.io",
     "starknet.org",
 
     "binance.org",


### PR DESCRIPTION
Adding **clobr.io** — CLOBr, a liquidity analytics platform for Solana tokens (aggregated liquidity depth across Meteora/Orca/Raydium DLMM pools, on-chain DCA order tracking, CEX depth).

It's an analytics/data tool with no TVL of its own, so it falls under this list per the README (websites which are not DeFi protocols with TVL).

- Website: https://clobr.io
- Official X: https://x.com/clobr_io
- Docs: https://clobr.io/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)