### PR TITLE
Add HyperBasis (Hyperliquid RWA basis & market terminal)

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -11,7 +11,6 @@
     "llama.fi",
     "llamao.fi",
     "smolrefuel.com",
-
     "zapper.xyz",
     "debank.com",
     "coingecko.com",
@@ -24,7 +23,6 @@
     "polygon.technology",
     "dexscreener.com",
     "starknet.org",
-
     "binance.org",
     "binance.com",
     "binance.us",
@@ -41,7 +39,6 @@
     "bitfinex.com",
     "layerswap.io",
     "squidrouter.com",
-
     "opensea.io",
     "looksrare.org",
     "decentraland.org",
@@ -79,7 +76,6 @@
     "christies.com",
     "hek.ch",
     "syrup.fi",
-
     "cloudflare.com",
     "github.com",
     "gitlab.com",
@@ -100,7 +96,6 @@
     "x.com",
     "warpcast.com",
     "hey.xyz",
-
     "etherscan.io",
     "bscscan.com",
     "snowtrace.io",
@@ -118,9 +113,9 @@
     "basescan.org",
     "axelarscan.io",
     "hyperlane.xyz",
-
     "rabby.io",
-    "rainbow.me"
+    "rainbow.me",
+    "hyperbasis.uk"
   ],
   "blacklist": [
     "defillaman.com",

--- a/domains.json
+++ b/domains.json
@@ -11,6 +11,7 @@
     "llama.fi",
     "llamao.fi",
     "smolrefuel.com",
+
     "zapper.xyz",
     "debank.com",
     "coingecko.com",
@@ -23,6 +24,7 @@
     "polygon.technology",
     "dexscreener.com",
     "starknet.org",
+
     "binance.org",
     "binance.com",
     "binance.us",
@@ -39,6 +41,7 @@
     "bitfinex.com",
     "layerswap.io",
     "squidrouter.com",
+
     "opensea.io",
     "looksrare.org",
     "decentraland.org",
@@ -76,6 +79,7 @@
     "christies.com",
     "hek.ch",
     "syrup.fi",
+
     "cloudflare.com",
     "github.com",
     "gitlab.com",
@@ -96,6 +100,7 @@
     "x.com",
     "warpcast.com",
     "hey.xyz",
+
     "etherscan.io",
     "bscscan.com",
     "snowtrace.io",
@@ -113,6 +118,7 @@
     "basescan.org",
     "axelarscan.io",
     "hyperlane.xyz",
+
     "rabby.io",
     "rainbow.me",
     "hyperbasis.uk"


### PR DESCRIPTION
Adding **hyperbasis.uk** — HyperBasis, an institutional cross-market basis and market intelligence terminal for Hyperliquid Real-World Asset (RWA) perpetual contracts (HIP-3 / trade.xyz).

It tracks real-world TradFi reference pricing (NASDAQ, NYSE, CME) vs Hyperliquid on-chain marks, oracle divergence lag, session states, and cash-and-carry yields.

It is an analytics and market intelligence terminal with no TVL of its own, falling under this list per the README (websites which are not DeFi protocols with TVL).

- Website: https://hyperbasis.uk
- Terminal: https://terminal.hyperbasis.uk
- API Reference: https://hyperbasis.uk/api-guide
- Asset Deep Dive (e.g. TSLA): https://hyperbasis.uk/rwa/asset/xyz:TSLA
- Bloomberg Terminal for On-Chain RWAs: https://hyperbasis.uk/bloomberg-terminal-on-chain-rwa